### PR TITLE
[Setting]: TextField 디자인 시스템 적용과 오류 수정

### DIFF
--- a/presentation/src/main/kotlin/ac/dnd/bookkeeping/android/presentation/common/view/textfield/TypingTextField.kt
+++ b/presentation/src/main/kotlin/ac/dnd/bookkeeping/android/presentation/common/view/textfield/TypingTextField.kt
@@ -1,0 +1,237 @@
+package ac.dnd.bookkeeping.android.presentation.common.view.textfield
+
+import ac.dnd.bookkeeping.android.presentation.R
+import ac.dnd.bookkeeping.android.presentation.common.theme.Body1
+import ac.dnd.bookkeeping.android.presentation.common.theme.Body2
+import ac.dnd.bookkeeping.android.presentation.common.theme.Gray400
+import ac.dnd.bookkeeping.android.presentation.common.theme.Gray600
+import ac.dnd.bookkeeping.android.presentation.common.theme.Gray800
+import ac.dnd.bookkeeping.android.presentation.common.theme.Negative
+import ac.dnd.bookkeeping.android.presentation.common.theme.Primary3
+import ac.dnd.bookkeeping.android.presentation.common.theme.Shapes
+import ac.dnd.bookkeeping.android.presentation.common.theme.Space20
+import ac.dnd.bookkeeping.android.presentation.common.theme.Space8
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun TypingTextField(
+    textType: TypingTextFieldType,
+    text: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    hintText: String = "",
+    isError: Boolean = false,
+    isEnabled: Boolean = true,
+    maxTextLength: Int = 100,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    leadingIconContent: (@Composable () -> Unit)? = null,
+    trailingIconContent: (@Composable () -> Unit)? = null,
+    errorMessageContent: (@Composable () -> Unit) = { },
+) {
+    val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    var isTextFieldFocused by remember { mutableStateOf(false) }
+
+    val isSingleLine = when (textType) {
+        TypingTextFieldType.Basic -> true
+        TypingTextFieldType.LongSentence -> false
+    }
+
+    val currentColor = if (isError) Negative else if (isTextFieldFocused) Primary3 else Gray400
+    val currentColorState = animateColorAsState(
+        targetValue = currentColor,
+        label = "color state"
+    )
+
+    Column {
+        Column(
+            modifier = modifier
+                .background(
+                    color = Color.White,
+                    shape = Shapes.medium
+                )
+                .border(
+                    width = 1.dp,
+                    shape = Shapes.medium,
+                    color = currentColorState.value
+                )
+                .wrapContentHeight()
+                .onFocusChanged {
+                    isTextFieldFocused = it.isFocused
+                }
+        ) {
+            BasicTextField(
+                value = text,
+                onValueChange = onValueChange,
+                enabled = isEnabled,
+                modifier = Modifier.fillMaxWidth(),
+                textStyle = Body1.merge(
+                    color = Gray800
+                ),
+                singleLine = isSingleLine,
+                minLines = if (isSingleLine) 1 else 3,
+                keyboardOptions = keyboardOptions,
+
+                cursorBrush = SolidColor(value = currentColorState.value),
+                interactionSource = interactionSource,
+            ) { textField ->
+                TextFieldDefaults.TextFieldDecorationBox(
+                    value = text,
+                    innerTextField = textField,
+                    enabled = isEnabled,
+                    singleLine = isSingleLine,
+                    visualTransformation = visualTransformation,
+                    interactionSource = interactionSource,
+                    placeholder = {
+                        Text(
+                            text = hintText,
+                            style = Body1.merge(color = Gray600)
+                        )
+                    },
+                    leadingIcon = leadingIconContent,
+                    trailingIcon = trailingIconContent,
+                    contentPadding = PaddingValues(
+                        vertical = 13.5.dp,
+                        horizontal = 16.dp
+                    )
+                )
+
+            }
+
+            if (textType == TypingTextFieldType.LongSentence) {
+                Spacer(Modifier.height(Space20))
+                Text(
+                    text = "${text.length}/$maxTextLength",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            top = 6.5.dp,
+                            end = 16.dp,
+                            bottom = 13.5.dp
+                        ),
+                    style = Body2.merge(color = Gray600),
+                    textAlign = TextAlign.End
+                )
+            }
+        }
+        if (textType == TypingTextFieldType.Basic) {
+            Spacer(Modifier.height(Space8))
+            Box(
+                modifier = Modifier
+                    .alpha(if (isError) 1f else 0f)
+            ) {
+                errorMessageContent()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TypingTextField1Preview() {
+    TypingTextField(
+        TypingTextFieldType.Basic,
+        text = "잘못 된 이름",
+        hintText = "이름을 입력하세요.",
+        modifier = Modifier.fillMaxWidth(),
+        onValueChange = {},
+        isError = true,
+        errorMessageContent = {
+            Text(
+                text = "에러 발생",
+                style = Body1.merge(color = Negative)
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun TypingTextField2Preview() {
+    TypingTextField(
+        TypingTextFieldType.Basic,
+        text = "이름",
+        hintText = "이름을 입력하세요.",
+        modifier = Modifier.fillMaxWidth(),
+        onValueChange = {},
+        isError = false,
+        errorMessageContent = {
+            Text(
+                text = "에러 발생",
+                style = Body1.merge(color = Negative)
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun TypingTextField3Preview() {
+    TypingTextField(
+        TypingTextFieldType.Basic,
+        text = "",
+        hintText = "이름을 입력하세요.",
+        modifier = Modifier.fillMaxWidth(),
+        onValueChange = {},
+        isError = false,
+        trailingIconContent = {
+            IconButton(
+                onClick = { }
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_close),
+                    contentDescription = "bottom icon",
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        },
+    )
+}
+
+@Preview
+@Composable
+fun TypingTextField4Preview() {
+    TypingTextField(
+        TypingTextFieldType.LongSentence,
+        text = "무릇은 경조사비 관리앱으로 사용자가 다양한 개인적인 축하 상황에 대해 금전적 기여를 쉽게 할 수 있게 돕는 모바일 애플리케이션입니다",
+        hintText = "",
+        onValueChange = {},
+
+        )
+}

--- a/presentation/src/main/kotlin/ac/dnd/bookkeeping/android/presentation/common/view/textfield/TypingTextFieldType.kt
+++ b/presentation/src/main/kotlin/ac/dnd/bookkeeping/android/presentation/common/view/textfield/TypingTextFieldType.kt
@@ -1,0 +1,6 @@
+package ac.dnd.bookkeeping.android.presentation.common.view.textfield
+
+sealed interface TypingTextFieldType {
+    data object Basic : TypingTextFieldType
+    data object LongSentence : TypingTextFieldType
+}

--- a/presentation/src/main/kotlin/ac/dnd/bookkeeping/android/presentation/ui/main/home/setting/SettingScreen.kt
+++ b/presentation/src/main/kotlin/ac/dnd/bookkeeping/android/presentation/ui/main/home/setting/SettingScreen.kt
@@ -1,26 +1,29 @@
 package ac.dnd.bookkeeping.android.presentation.ui.main.home.setting
 
 import ac.dnd.bookkeeping.android.presentation.R
+import ac.dnd.bookkeeping.android.presentation.common.theme.Body1
+import ac.dnd.bookkeeping.android.presentation.common.theme.Negative
 import ac.dnd.bookkeeping.android.presentation.common.util.ErrorObserver
 import ac.dnd.bookkeeping.android.presentation.common.view.BottomSheetScreen
-import ac.dnd.bookkeeping.android.presentation.common.view.CustomTextField
 import ac.dnd.bookkeeping.android.presentation.common.view.DialogScreen
 import ac.dnd.bookkeeping.android.presentation.common.view.confirm.ConfirmButton
 import ac.dnd.bookkeeping.android.presentation.common.view.confirm.ConfirmButtonProperties
 import ac.dnd.bookkeeping.android.presentation.common.view.confirm.ConfirmButtonSize
 import ac.dnd.bookkeeping.android.presentation.common.view.confirm.ConfirmButtonType
+import ac.dnd.bookkeeping.android.presentation.common.view.textfield.TypingTextField
+import ac.dnd.bookkeeping.android.presentation.common.view.textfield.TypingTextFieldType
 import ac.dnd.bookkeeping.android.presentation.ui.main.ApplicationState
 import ac.dnd.bookkeeping.android.presentation.ui.main.home.event.common.relation.SearchRelationScreen
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -34,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,7 +56,8 @@ fun SettingScreen(
     var isDialogShowing by remember { mutableStateOf(false) }
     var isBottomSheetShowing by remember { mutableStateOf(false) }
     var isSearchRelationShowing by remember { mutableStateOf(false) }
-    var searchText by remember { mutableStateOf(TextFieldValue()) }
+    var searchText by remember { mutableStateOf("") }
+    var isErrorText by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -63,28 +66,39 @@ fun SettingScreen(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        CustomTextField(
-            text = searchText.text,
-            onTextChange = {
-                searchText = TextFieldValue(it)
+        TypingTextField(
+            TypingTextFieldType.Basic,
+            text = searchText,
+            hintText = "이름을 입력하세요.",
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp),
+            onValueChange = {
+                searchText = it
+                isErrorText = searchText.length > 5
             },
+            isError = isErrorText,
             trailingIconContent = {
-                if (searchText.text.isNotEmpty()) {
-                    IconButton(
-                        onClick = { searchText = TextFieldValue() }
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_close),
-                            contentDescription = "bottom icon"
-                        )
+                IconButton(
+                    onClick = {
+                        searchText = ""
+                        isErrorText = false
                     }
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_close),
+                        contentDescription = "bottom icon",
+                        modifier = Modifier.size(20.dp)
+                    )
                 }
             },
-            hintTextContent = {
-                Text(text = "이름 입력 (1~15자)", color = Color.LightGray)
-            },
-            contentInnerPadding = PaddingValues(horizontal = 10.dp),
-            contentOuterPadding = PaddingValues(horizontal = 10.dp)
+            errorMessageContent = {
+                Text(
+                    text = "에러 발생",
+                    style = Body1.merge(color = Negative),
+                    modifier = Modifier.padding(start = 10.dp)
+                )
+            }
         )
         Text(
             text = "Setting",


### PR DESCRIPTION
## **설명**
- CustomTextField -> textfield - TypingTextField로 수정하였습니다.
- 텍스트 필드를 재구성하고 modifier를 활용해서 크기를 조정할 수 있도록 수정하였습니다.
- 커서, 텍스트 등 저희 디자인에 맞도록 수정하였습니다.
- LongSentence 타입에 대해 구현이 가능하도록 하였습니다.


## 참고
- errorMessageContent()로 에러 메시지를 전달하도록 하였습니다.
- 메시지를 TextField에서 나타내도록 수정해보려 했는데 에러 메시지를 위해 OutlineTextField 사용 -> 패딩 값 조절 불가능으로 그냥 (BasicTextField + 커스텀)으로 구현하였습니다. 
![스크린샷 2024-01-30 오후 5 48 42](https://github.com/dnd-side-project/dnd-10th-8-android/assets/85734140/1e7a9410-fd91-4183-90a2-f454b7bc2868)


## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [ ] : 실제 기기에서 테스트를 진행하셨나요?
